### PR TITLE
Fix invalid handling of fields with "id" or "dead" inside them

### DIFF
--- a/src/RosApiCommands.ts
+++ b/src/RosApiCommands.ts
@@ -31,7 +31,7 @@ export class RosApiCommands extends RouterOSAPICrud {
 
         for (let i = 0; i < fields.length; i++) {
             const field = fields[i];
-            if (/id|dead|nextid/.test(field)) fields[i] = "." + field;
+            if (/^(id|dead|nextid)$/.test(field)) fields[i] = "." + field;
         }
 
         // Convert array to a string comma separated 


### PR DESCRIPTION
Like if you want to `.select(['id','bridge','interface'])` it will prefix both id and bridge with a dot. Which would not work as expected.